### PR TITLE
Provides an extension to Crawler4J for crawling dynamic web pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+
+logs/

--- a/crawler4j-commons/src/main/java/edu/uci/ics/crawler4j/crawler/DynamicCrawlConfig.java
+++ b/crawler4j-commons/src/main/java/edu/uci/ics/crawler4j/crawler/DynamicCrawlConfig.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * de.hs-heilbronn.mi:crawler4j-core
+ * %%
+ * Copyright (C) 2010 - 2021 crawler4j-fork (pre-fork: Yasser Ganjisaffar)
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package edu.uci.ics.crawler4j.crawler;
 
 import java.nio.file.FileSystems;

--- a/crawler4j-commons/src/main/java/edu/uci/ics/crawler4j/crawler/DynamicCrawlConfig.java
+++ b/crawler4j-commons/src/main/java/edu/uci/ics/crawler4j/crawler/DynamicCrawlConfig.java
@@ -1,0 +1,101 @@
+package edu.uci.ics.crawler4j.crawler;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+
+import static edu.uci.ics.crawler4j.crawler.DynamicCrawlConfig.WebDriverType.firefox;
+
+/**
+ * Extends {@link CrawlConfig} to add configuration properties for the Selenium's <em>WebDriver</em>.
+ */
+public class DynamicCrawlConfig extends CrawlConfig {
+
+    public enum WebDriverType {
+        chrome,
+        firefox
+    }
+
+    private WebDriverType webDriverType = firefox;
+
+    /**
+     * If dynamic content crawling is used, the maximum time to wait for dynamic content loading in seconds.
+     */
+    private int maxWaitForDynamicContentInSeconds = 2;
+
+    /**
+     * Absolute path to the driver binary on the local filesystem.
+     */
+    private String webDriverPath;
+
+    /**
+     * The user agent to be used by the web driver.
+     */
+    private String webDriverUserAgent;
+
+    /**
+     * Additional options for the web driver, that will be added to the default ones.
+     */
+    private List<String> webDriverOptions = Collections.emptyList();
+
+    public int getMaxWaitForDynamicContentInSeconds() {
+        return maxWaitForDynamicContentInSeconds;
+    }
+
+    public void setMaxWaitForDynamicContentInSeconds(int maxWaitForDynamicContentInSeconds) {
+        this.maxWaitForDynamicContentInSeconds = maxWaitForDynamicContentInSeconds;
+    }
+
+    public String getWebDriverPath() {
+        return webDriverPath;
+    }
+
+    public void setWebDriverPath(String webDriverPath) {
+        this.webDriverPath = webDriverPath;
+    }
+
+    public WebDriverType getWebDriverType() {
+        return webDriverType;
+    }
+
+    public void setWebDriverType(WebDriverType webDriverType) {
+        this.webDriverType = webDriverType;
+    }
+
+    public List<String> getWebDriverOptions() {
+        return webDriverOptions;
+    }
+
+    public void setWebDriverOptions(List<String> webDriverOptions) {
+        this.webDriverOptions = webDriverOptions;
+    }
+
+    public String getWebDriverUserAgent() {
+        return webDriverUserAgent;
+    }
+
+    public void setWebDriverUserAgent(String webDriverUserAgent) {
+        this.webDriverUserAgent = webDriverUserAgent;
+    }
+
+    @Override
+    public void validate() throws Exception {
+        super.validate();
+
+        if (!Files.exists(FileSystems.getDefault().getPath(webDriverPath))) {
+            throw new Exception("Headless browser driver not found at " + webDriverPath);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() +
+                "Web driver type:: " + webDriverType + "\n" +
+                "Web driver path:: " + webDriverPath + "\n" +
+                "Web driver user agent:: " + webDriverUserAgent + "\n" +
+                "Web driver options:: " + String.join(" ", webDriverOptions) + "\n" +
+                "Max wait for dynamic content loading in seconds:: " + maxWaitForDynamicContentInSeconds + "\n";
+    }
+
+}

--- a/crawler4j-core/pom.xml
+++ b/crawler4j-core/pom.xml
@@ -186,19 +186,25 @@
                 </exclusion>
             </exclusions>
         </dependency>
-					<!-- Test dependencies -->
-					<dependency>
-						<groupId>org.junit.jupiter</groupId>
-						<artifactId>junit-jupiter</artifactId>
-						<version>${junit.version}</version>
-						<scope>test</scope>
-					</dependency>
-					<dependency>
-						<groupId>org.assertj</groupId>
-						<artifactId>assertj-core</artifactId>
-						<version>${assertj.version}</version>
-						<scope>test</scope>
-					</dependency>
+        <!-- Selenium Java -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>${selenium.version}</version>
+        </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>de.hs-heilbronn.mi</groupId>

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/crawler/dynamic/DynamicCrawlerHelper.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/crawler/dynamic/DynamicCrawlerHelper.java
@@ -1,0 +1,67 @@
+package edu.uci.ics.crawler4j.crawler.dynamic;
+
+import crawlercommons.filters.basic.BasicURLNormalizer;
+import edu.uci.ics.crawler4j.crawler.CrawlController;
+import edu.uci.ics.crawler4j.crawler.DynamicCrawlConfig;
+import edu.uci.ics.crawler4j.crawler.Page;
+import edu.uci.ics.crawler4j.fetcher.PageFetcher;
+import edu.uci.ics.crawler4j.frontier.FrontierConfiguration;
+import edu.uci.ics.crawler4j.parser.dynamic.DynamicParser;
+import edu.uci.ics.crawler4j.robotstxt.RobotstxtConfig;
+import edu.uci.ics.crawler4j.robotstxt.RobotstxtServer;
+import edu.uci.ics.crawler4j.url.TLDList;
+import org.openqa.selenium.By;
+
+import java.util.function.BiFunction;
+
+/**
+ * Helper class that provides factory methods for a {@link CrawlController} set up for headless browser crawling.
+ */
+public class DynamicCrawlerHelper {
+
+    /**
+     * Sets up a ready to use {@link CrawlController} with a default URL normalizer
+     * @param config the {@link DynamicCrawlConfig}
+     * @param waitSelectorSupplier provides a selector clause for a {@link Page} given a {@link DynamicCrawlConfig} that
+     *                             will be used to wait for dynamic content loading.
+     * @param robotstxtConfig the robots.txt config to use
+     * @param frontierConfiguration the frontier implementation to use
+     * @return a ready to use {@link CrawlController}
+     * @throws Exception
+     */
+    public static CrawlController crawlControllerFactory(
+            DynamicCrawlConfig config,
+            BiFunction<DynamicCrawlConfig, Page, By> waitSelectorSupplier,
+            RobotstxtConfig robotstxtConfig,
+            FrontierConfiguration frontierConfiguration) throws Exception {
+        return crawlControllerFactory(config, waitSelectorSupplier, robotstxtConfig, frontierConfiguration,
+                BasicURLNormalizer.newBuilder().idnNormalization(BasicURLNormalizer.IdnNormalization.NONE).build());
+    }
+
+    /**
+     * Sets up a ready to use {@link CrawlController} with a specific URL normalizer
+     * @param config the {@link DynamicCrawlConfig}
+     * @param waitSelectorSupplier provides a selector clause for a {@link Page} given a {@link DynamicCrawlConfig} that
+     *                             will be used to wait for dynamic content loading.
+     * @param robotstxtConfig the robots.txt config to use
+     * @param frontierConfiguration the frontier implementation to use
+     * @param normalizer the URL normalizer to use
+     * @return a ready to use {@link CrawlController}
+     * @throws Exception
+     */
+    public static CrawlController crawlControllerFactory(
+            DynamicCrawlConfig config,
+            BiFunction<DynamicCrawlConfig, Page, By> waitSelectorSupplier,
+            RobotstxtConfig robotstxtConfig,
+            FrontierConfiguration frontierConfiguration,
+            BasicURLNormalizer normalizer) throws Exception {
+        PageFetcher pageFetcher = new PageFetcher(config, normalizer);
+        RobotstxtServer robotstxtServer = new RobotstxtServer(
+                robotstxtConfig, pageFetcher, frontierConfiguration.getWebURLFactory());
+        TLDList tldList = new TLDList(config);
+        DynamicParser parser = new DynamicParser(
+                config, normalizer, tldList, frontierConfiguration.getWebURLFactory(), waitSelectorSupplier);
+        return new CrawlController(config, normalizer, pageFetcher, parser, robotstxtServer, tldList, frontierConfiguration);
+    }
+
+}

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/crawler/dynamic/DynamicCrawlerHelper.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/crawler/dynamic/DynamicCrawlerHelper.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * de.hs-heilbronn.mi:crawler4j-core
+ * %%
+ * Copyright (C) 2010 - 2021 crawler4j-fork (pre-fork: Yasser Ganjisaffar)
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package edu.uci.ics.crawler4j.crawler.dynamic;
 
 import crawlercommons.filters.basic.BasicURLNormalizer;

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/crawler/dynamic/DynamicCrawlerHelper.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/crawler/dynamic/DynamicCrawlerHelper.java
@@ -22,16 +22,13 @@ package edu.uci.ics.crawler4j.crawler.dynamic;
 import crawlercommons.filters.basic.BasicURLNormalizer;
 import edu.uci.ics.crawler4j.crawler.CrawlController;
 import edu.uci.ics.crawler4j.crawler.DynamicCrawlConfig;
-import edu.uci.ics.crawler4j.crawler.Page;
 import edu.uci.ics.crawler4j.fetcher.PageFetcher;
 import edu.uci.ics.crawler4j.frontier.FrontierConfiguration;
+import edu.uci.ics.crawler4j.parser.dynamic.DynamicContentLoadingFinishedPredicate;
 import edu.uci.ics.crawler4j.parser.dynamic.DynamicParser;
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtConfig;
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtServer;
 import edu.uci.ics.crawler4j.url.TLDList;
-import org.openqa.selenium.By;
-
-import java.util.function.BiFunction;
 
 /**
  * Helper class that provides factory methods for a {@link CrawlController} set up for headless browser crawling.
@@ -41,8 +38,7 @@ public class DynamicCrawlerHelper {
     /**
      * Sets up a ready to use {@link CrawlController} with a default URL normalizer
      * @param config the {@link DynamicCrawlConfig}
-     * @param waitSelectorSupplier provides a selector clause for a {@link Page} given a {@link DynamicCrawlConfig} that
-     *                             will be used to wait for dynamic content loading.
+     * @param waitPredicate predicate to detect if dynamic content loading is finished.
      * @param robotstxtConfig the robots.txt config to use
      * @param frontierConfiguration the frontier implementation to use
      * @return a ready to use {@link CrawlController}
@@ -50,18 +46,17 @@ public class DynamicCrawlerHelper {
      */
     public static CrawlController crawlControllerFactory(
             DynamicCrawlConfig config,
-            BiFunction<DynamicCrawlConfig, Page, By> waitSelectorSupplier,
+            DynamicContentLoadingFinishedPredicate waitPredicate,
             RobotstxtConfig robotstxtConfig,
             FrontierConfiguration frontierConfiguration) throws Exception {
-        return crawlControllerFactory(config, waitSelectorSupplier, robotstxtConfig, frontierConfiguration,
+        return crawlControllerFactory(config, waitPredicate, robotstxtConfig, frontierConfiguration,
                 BasicURLNormalizer.newBuilder().idnNormalization(BasicURLNormalizer.IdnNormalization.NONE).build());
     }
 
     /**
      * Sets up a ready to use {@link CrawlController} with a specific URL normalizer
      * @param config the {@link DynamicCrawlConfig}
-     * @param waitSelectorSupplier provides a selector clause for a {@link Page} given a {@link DynamicCrawlConfig} that
-     *                             will be used to wait for dynamic content loading.
+     * @param waitPredicate a predicate to detect if dynamic content loading is finished.
      * @param robotstxtConfig the robots.txt config to use
      * @param frontierConfiguration the frontier implementation to use
      * @param normalizer the URL normalizer to use
@@ -70,7 +65,7 @@ public class DynamicCrawlerHelper {
      */
     public static CrawlController crawlControllerFactory(
             DynamicCrawlConfig config,
-            BiFunction<DynamicCrawlConfig, Page, By> waitSelectorSupplier,
+            DynamicContentLoadingFinishedPredicate waitPredicate,
             RobotstxtConfig robotstxtConfig,
             FrontierConfiguration frontierConfiguration,
             BasicURLNormalizer normalizer) throws Exception {
@@ -79,7 +74,7 @@ public class DynamicCrawlerHelper {
                 robotstxtConfig, pageFetcher, frontierConfiguration.getWebURLFactory());
         TLDList tldList = new TLDList(config);
         DynamicParser parser = new DynamicParser(
-                config, normalizer, tldList, frontierConfiguration.getWebURLFactory(), waitSelectorSupplier);
+                config, normalizer, tldList, frontierConfiguration.getWebURLFactory(), waitPredicate);
         return new CrawlController(config, normalizer, pageFetcher, parser, robotstxtServer, tldList, frontierConfiguration);
     }
 

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/crawler/dynamic/DynamicWebCrawler.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/crawler/dynamic/DynamicWebCrawler.java
@@ -28,9 +28,7 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import static edu.uci.ics.crawler4j.crawler.DynamicCrawlConfig.headlessBrowserOptions;
 
 /**
  * Extends {@link WebCrawler} for using a Selenium {@link WebDriver} to fetch dynamically generated HTML pages.
@@ -52,39 +50,16 @@ public class DynamicWebCrawler extends WebCrawler {
         this.webDriver.close();
     }
 
-    /**
-     * Default options for the headless browser
-     * @param config the {@link DynamicCrawlConfig} where the user agent is defined.
-     * @return the default options for the headless browser
-     */
-    public List<String> defaultHeadlessBrowserOptions(DynamicCrawlConfig config) {
-        return Arrays.asList(
-                "--headless",
-                "--disable-gpu",
-                "--window-size=1920,1080",
-                "--ignore-certificate-errors",
-                "--user-agent=" + config.getWebDriverUserAgent());
-    }
-
-    /**
-     * Browser options defined in {@link DynamicCrawlConfig#getWebDriverOptions()} are concatenated to default options.
-     */
-    private String[] headlessBrowserOptions(DynamicCrawlConfig config) {
-        List<String> options = new ArrayList<>();
-        options.addAll(defaultHeadlessBrowserOptions(config));
-        options.addAll(config.getWebDriverOptions());
-        return options.toArray(String[]::new);
-    }
-
     private WebDriver newWebDriverInstance(DynamicCrawlConfig config) {
-        System.setProperty("webdriver.firefox.driver", config.getWebDriverPath());
-
+        String driverPath = config.getWebDriverPath().toString();
         switch (config.getWebDriverType()) {
             case chrome:
+                System.setProperty("webdriver.chrome.driver", driverPath);
                 ChromeOptions chromeOptions = new ChromeOptions();
                 chromeOptions.addArguments(headlessBrowserOptions(config));
                 return new ChromeDriver(chromeOptions);
             case firefox:
+                System.setProperty("webdriver.firefox.driver", driverPath);
                 FirefoxOptions firefoxOptions = new FirefoxOptions();
                 firefoxOptions.addArguments(headlessBrowserOptions(config));
                 return new FirefoxDriver(firefoxOptions);

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/crawler/dynamic/DynamicWebCrawler.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/crawler/dynamic/DynamicWebCrawler.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * de.hs-heilbronn.mi:crawler4j-core
+ * %%
+ * Copyright (C) 2010 - 2021 crawler4j-fork (pre-fork: Yasser Ganjisaffar)
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package edu.uci.ics.crawler4j.crawler.dynamic;
 
 import edu.uci.ics.crawler4j.crawler.DynamicCrawlConfig;

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/crawler/dynamic/DynamicWebCrawler.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/crawler/dynamic/DynamicWebCrawler.java
@@ -1,0 +1,77 @@
+package edu.uci.ics.crawler4j.crawler.dynamic;
+
+import edu.uci.ics.crawler4j.crawler.DynamicCrawlConfig;
+import edu.uci.ics.crawler4j.crawler.WebCrawler;
+import edu.uci.ics.crawler4j.parser.dynamic.DynamicParser;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Extends {@link WebCrawler} for using a Selenium {@link WebDriver} to fetch dynamically generated HTML pages.
+ */
+public class DynamicWebCrawler extends WebCrawler {
+
+    private WebDriver webDriver;
+
+    @Override
+    public void onStart() {
+        // Instantiate and register the WebDriver instance for this crawler thread to the parser.
+        // This is due to the fact Selenium's WebDriver is not thread-safe.
+        webDriver = newWebDriverInstance((DynamicCrawlConfig) getMyController().getConfig());
+        ((DynamicParser) getMyController().getParser()).setWebDriver(webDriver);
+    }
+
+    @Override
+    public void onBeforeExit() {
+        this.webDriver.close();
+    }
+
+    /**
+     * Default options for the headless browser
+     * @param config the {@link DynamicCrawlConfig} where the user agent is defined.
+     * @return the default options for the headless browser
+     */
+    public List<String> defaultHeadlessBrowserOptions(DynamicCrawlConfig config) {
+        return Arrays.asList(
+                "--headless",
+                "--disable-gpu",
+                "--window-size=1920,1080",
+                "--ignore-certificate-errors",
+                "--user-agent=" + config.getWebDriverUserAgent());
+    }
+
+    /**
+     * Browser options defined in {@link DynamicCrawlConfig#getWebDriverOptions()} are concatenated to default options.
+     */
+    private String[] headlessBrowserOptions(DynamicCrawlConfig config) {
+        List<String> options = new ArrayList<>();
+        options.addAll(defaultHeadlessBrowserOptions(config));
+        options.addAll(config.getWebDriverOptions());
+        return options.toArray(String[]::new);
+    }
+
+    private WebDriver newWebDriverInstance(DynamicCrawlConfig config) {
+        System.setProperty("webdriver.firefox.driver", config.getWebDriverPath());
+
+        switch (config.getWebDriverType()) {
+            case chrome:
+                ChromeOptions chromeOptions = new ChromeOptions();
+                chromeOptions.addArguments(headlessBrowserOptions(config));
+                return new ChromeDriver(chromeOptions);
+            case firefox:
+                FirefoxOptions firefoxOptions = new FirefoxOptions();
+                firefoxOptions.addArguments(headlessBrowserOptions(config));
+                return new FirefoxDriver(firefoxOptions);
+            default:
+                throw new IllegalArgumentException("Not reached");
+        }
+    }
+
+}

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/TikaHtmlParser.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/TikaHtmlParser.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import crawlercommons.filters.basic.BasicURLNormalizer;
+import edu.uci.ics.crawler4j.crawler.DynamicCrawlConfig;
 import edu.uci.ics.crawler4j.url.UrlResolver;
 import edu.uci.ics.crawler4j.url.WebURLFactory;
 import org.apache.tika.metadata.DublinCore;
@@ -148,6 +149,10 @@ public class TikaHtmlParser implements edu.uci.ics.crawler4j.parser.HtmlParser {
 
     protected boolean containsForbiddenRefTag(String href) {
         return Stream.of("about:", "tel:", "data:", "whatsapp:", "javascript:", "viber:", "sms:", "android-app:", "fb-messenger:", "mailto:", "@").anyMatch(href::contains);
+    }
+
+    protected CrawlConfig getCrawlConfig() {
+        return config;
     }
 
     private String chooseEncoding(Page page, Metadata metadata) {

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/dynamic/DynamicContentLoadingFinishedPredicate.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/dynamic/DynamicContentLoadingFinishedPredicate.java
@@ -1,0 +1,18 @@
+package edu.uci.ics.crawler4j.parser.dynamic;
+
+import edu.uci.ics.crawler4j.crawler.DynamicCrawlConfig;
+import edu.uci.ics.crawler4j.crawler.Page;
+import org.openqa.selenium.WebDriver;
+
+@FunctionalInterface
+public interface DynamicContentLoadingFinishedPredicate<V> {
+
+    /**
+     * Given a {@link DynamicCrawlConfig}, return whether dynamic content finished loading for the given {@link Page}.
+     * @param config the crawl configuration
+     * @param page the page nbeing crawled
+     * @param webDriver the WebDriver being used
+     * @return true dynamic content finished loading, false otherwise
+     */
+    V test(final DynamicCrawlConfig config, final Page page, final WebDriver webDriver);
+}

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/dynamic/DynamicParser.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/dynamic/DynamicParser.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * de.hs-heilbronn.mi:crawler4j-core
+ * %%
+ * Copyright (C) 2010 - 2021 crawler4j-fork (pre-fork: Yasser Ganjisaffar)
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package edu.uci.ics.crawler4j.parser.dynamic;
 
 import crawlercommons.filters.basic.BasicURLNormalizer;

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/dynamic/DynamicParser.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/dynamic/DynamicParser.java
@@ -1,0 +1,44 @@
+package edu.uci.ics.crawler4j.parser.dynamic;
+
+import crawlercommons.filters.basic.BasicURLNormalizer;
+import edu.uci.ics.crawler4j.crawler.DynamicCrawlConfig;
+import edu.uci.ics.crawler4j.crawler.Page;
+import edu.uci.ics.crawler4j.crawler.dynamic.DynamicWebCrawler;
+import edu.uci.ics.crawler4j.parser.Parser;
+import edu.uci.ics.crawler4j.url.TLDList;
+import edu.uci.ics.crawler4j.url.WebURLFactory;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+import java.io.IOException;
+import java.util.function.BiFunction;
+
+/**
+ * Extends {@link Parser} to use {@link DynamicTikaHtmlParser} and provides a setter method so that
+ * {@link edu.uci.ics.crawler4j.crawler.WebCrawler} can register a {@link WebDriver} instance ofr itself.
+ */
+public class DynamicParser extends Parser {
+
+    public DynamicParser(
+            DynamicCrawlConfig config,
+            BasicURLNormalizer normalizer,
+            TLDList tldList,
+            WebURLFactory webURLFactory,
+            BiFunction<DynamicCrawlConfig, Page, By> waitSelectorSupplier) throws IOException {
+        super(
+                config,
+                normalizer,
+                new DynamicTikaHtmlParser(config, normalizer, tldList, webURLFactory, waitSelectorSupplier),
+                tldList,
+                webURLFactory);
+    }
+
+    /**
+     * Sets the {@link WebDriver} instance for a given crawler thread (called by {@link DynamicWebCrawler#onStart()});
+     * @param webDriver
+     */
+    public void setWebDriver(WebDriver webDriver) {
+        ((DynamicTikaHtmlParser) getHtmlContentParser()).setWebDriver(webDriver);
+    }
+
+}

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/dynamic/DynamicParser.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/dynamic/DynamicParser.java
@@ -31,6 +31,7 @@ import org.openqa.selenium.WebDriver;
 
 import java.io.IOException;
 import java.util.function.BiFunction;
+import java.util.function.Predicate;
 
 /**
  * Extends {@link Parser} to use {@link DynamicTikaHtmlParser} and provides a setter method so that
@@ -43,11 +44,11 @@ public class DynamicParser extends Parser {
             BasicURLNormalizer normalizer,
             TLDList tldList,
             WebURLFactory webURLFactory,
-            BiFunction<DynamicCrawlConfig, Page, By> waitSelectorSupplier) throws IOException {
+            DynamicContentLoadingFinishedPredicate waitPredicate) throws IOException {
         super(
                 config,
                 normalizer,
-                new DynamicTikaHtmlParser(config, normalizer, tldList, webURLFactory, waitSelectorSupplier),
+                new DynamicTikaHtmlParser(config, normalizer, tldList, webURLFactory, waitPredicate),
                 tldList,
                 webURLFactory);
     }

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/dynamic/DynamicTikaHtmlParser.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/dynamic/DynamicTikaHtmlParser.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * de.hs-heilbronn.mi:crawler4j-core
+ * %%
+ * Copyright (C) 2010 - 2021 crawler4j-fork (pre-fork: Yasser Ganjisaffar)
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package edu.uci.ics.crawler4j.parser.dynamic;
 
 import crawlercommons.filters.basic.BasicURLNormalizer;

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/dynamic/DynamicTikaHtmlParser.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/dynamic/DynamicTikaHtmlParser.java
@@ -1,0 +1,105 @@
+package edu.uci.ics.crawler4j.parser.dynamic;
+
+import crawlercommons.filters.basic.BasicURLNormalizer;
+import edu.uci.ics.crawler4j.crawler.DynamicCrawlConfig;
+import edu.uci.ics.crawler4j.crawler.Page;
+import edu.uci.ics.crawler4j.crawler.exceptions.PageBiggerThanMaxSizeException;
+import edu.uci.ics.crawler4j.crawler.exceptions.ParseException;
+import edu.uci.ics.crawler4j.parser.HtmlParseData;
+import edu.uci.ics.crawler4j.parser.TikaHtmlParser;
+import edu.uci.ics.crawler4j.url.TLDList;
+import edu.uci.ics.crawler4j.url.WebURLFactory;
+import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.nio.charset.Charset;
+import java.time.Duration;
+import java.util.function.BiFunction;
+
+/**
+ * Overrides {@link TikaHtmlParser} so that the page content is fetched using Selenium's {@link WebDriver}.
+ * A programmatic wait for dynamic content loading is performed prior to content fetching, which content we should wait
+ * for is defined by {@link DynamicTikaHtmlParser#waitSelectorSupplier}.
+ *
+ * Since {@link WebDriver} is not thread safe, we use a {@link ThreadLocal} wrapper. The {@link WebDriver} for each
+ * thread should be provided through the {@link DynamicTikaHtmlParser#setWebDriver(WebDriver)} method.
+ */
+public class DynamicTikaHtmlParser extends TikaHtmlParser {
+
+    /**
+     * Holds a {@link WebDriver} instance per crawler thread.
+     */
+    private final ThreadLocal<WebDriver> webDriver;
+
+    /**
+     * A function that provides a selector clause for a {@link Page} given a {@link DynamicCrawlConfig}.
+     * This selector will be used to wait for dynamic content loading.
+     */
+    private final BiFunction<DynamicCrawlConfig, Page, By> waitSelectorSupplier;
+
+    /**
+     * The maximum time in seconds to for dynamic content loading.
+     */
+    private int maxWaitForDynamicContentInSeconds;
+
+    public DynamicTikaHtmlParser(
+            DynamicCrawlConfig config,
+            BasicURLNormalizer normalizer,
+            TLDList tldList,
+            WebURLFactory webURLFactory,
+            BiFunction<DynamicCrawlConfig, Page, By> waitSelectorSupplier) {
+        super(config, normalizer, tldList, webURLFactory);
+        this.webDriver = new ThreadLocal<>();
+        this.waitSelectorSupplier = waitSelectorSupplier;
+        this.maxWaitForDynamicContentInSeconds = config.getMaxWaitForDynamicContentInSeconds();
+    }
+
+    /**
+     * Sets the {@link WebDriver} instance for a given crawler thread.
+     * @param webDriver
+     */
+    public void setWebDriver(WebDriver webDriver) {
+        this.webDriver.set(webDriver);
+    }
+
+    public HtmlParseData parse(Page page, String contextURL) throws ParseException {
+        try {
+            page.setContentData(fetchPageSource(page));
+        } catch (PageBiggerThanMaxSizeException e) {
+            throw new ParseException(e);
+        }
+        return super.parse(page, contextURL);
+    }
+
+    /**
+     * Fetches the page source using the {@link WebDriver} instance for the crawler thread,
+     * after waiting for dynamic content loading according to the configured wait time and selector.
+     * @param page the page being crawled
+     * @return the page source as a byte array
+     */
+    protected byte[] fetchPageSource(Page page) throws PageBiggerThanMaxSizeException {
+        String url = page.getWebURL().getURL();
+        webDriver.get().navigate().to(url);
+
+        By selector = waitSelectorSupplier.apply((DynamicCrawlConfig) getCrawlConfig(), page);
+        try {
+            new WebDriverWait(
+                    webDriver.get(),
+                    Duration.ofSeconds(maxWaitForDynamicContentInSeconds))
+                    .until(d -> d.findElement(selector));
+        } catch (final TimeoutException e) {
+            logger.warn("Wait on {} timed out for {}", selector, url);
+        }
+
+        byte[] pageSource = webDriver.get().getPageSource().getBytes(Charset.forName(page.getContentCharset()));
+        int contentSize = pageSource.length;
+        if (contentSize > getCrawlConfig().getMaxDownloadSize()) {
+            throw new PageBiggerThanMaxSizeException(contentSize);
+        }
+
+        return pageSource;
+    }
+
+}

--- a/crawler4j-examples/crawler4j-examples-dynamic/.gitignore
+++ b/crawler4j-examples/crawler4j-examples-dynamic/.gitignore
@@ -1,0 +1,1 @@
+/frontier/

--- a/crawler4j-examples/crawler4j-examples-dynamic/pom.xml
+++ b/crawler4j-examples/crawler4j-examples-dynamic/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>crawler4j-examples</artifactId>
+        <groupId>de.hs-heilbronn.mi</groupId>
+        <version>5.0.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>crawler4j-examples-dynamic</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <dependencies>
+        <dependency>
+            <groupId>de.hs-heilbronn.mi</groupId>
+            <artifactId>crawler4j-with-sleepycat</artifactId>
+            <version>${crawler4j.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>de.hs-heilbronn.mi</groupId>
+            <artifactId>crawler4j-with-hsqldb</artifactId>
+            <version>${crawler4j.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>de.hs-heilbronn.mi</groupId>
+            <artifactId>crawler4j-with-urlfrontier</artifactId>
+            <version>${crawler4j.version}</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/crawler4j-examples/crawler4j-examples-dynamic/src/test/java/edu/uci/ics/crawler4j/examples/dynamic/BasicCrawler.java
+++ b/crawler4j-examples/crawler4j-examples-dynamic/src/test/java/edu/uci/ics/crawler4j/examples/dynamic/BasicCrawler.java
@@ -1,0 +1,110 @@
+/*-
+ * #%L
+ * de.hs-heilbronn.mi:crawler4j-examples-base
+ * %%
+ * Copyright (C) 2010 - 2021 crawler4j-fork (pre-fork: Yasser Ganjisaffar)
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package edu.uci.ics.crawler4j.examples.dynamic;
+
+import edu.uci.ics.crawler4j.crawler.Page;
+import edu.uci.ics.crawler4j.crawler.WebCrawler;
+import edu.uci.ics.crawler4j.parser.HtmlParseData;
+import edu.uci.ics.crawler4j.url.WebURL;
+import org.apache.hc.core5.http.Header;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+public class BasicCrawler extends WebCrawler {
+
+    private static final Pattern IMAGE_EXTENSIONS = Pattern.compile(".*\\.(bmp|gif|jpg|png)$");
+
+    private final AtomicInteger numSeenImages;
+
+    /**
+     * Creates a new crawler instance.
+     *
+     * @param numSeenImages This is just an example to demonstrate how you can pass objects to crawlers. In this
+     * example, we pass an AtomicInteger to all crawlers, and they increment it whenever they see an url which points
+     * to an image.
+     */
+    public BasicCrawler(AtomicInteger numSeenImages) {
+        this.numSeenImages = numSeenImages;
+    }
+
+    /**
+     * You should implement this function to specify whether the given url
+     * should be crawled or not (based on your crawling logic).
+     */
+    @Override
+    public boolean shouldVisit(Page referringPage, WebURL url) {
+        String href = url.getURL().toLowerCase(Locale.ROOT);
+        // Ignore the url if it has an extension that matches our defined set of image extensions.
+        if (IMAGE_EXTENSIONS.matcher(href).matches()) {
+            numSeenImages.incrementAndGet();
+            return false;
+        }
+
+        // Only accept the url if it is in the "www.ics.uci.edu" domain and protocol is "http".
+        return href.startsWith("https://www.ics.uci.edu/");
+    }
+
+    /**
+     * This function is called when a page is fetched and ready to be processed
+     * by your program.
+     */
+    @Override
+    public void visit(Page page) {
+        int docid = page.getWebURL().getDocid();
+        String url = page.getWebURL().getURL();
+        String domain = page.getWebURL().getDomain();
+        String path = page.getWebURL().getPath();
+        String subDomain = page.getWebURL().getSubDomain();
+        String parentUrl = page.getWebURL().getParentUrl();
+        String anchor = page.getWebURL().getAnchor();
+
+        logger.debug("Docid: {}", docid);
+        logger.info("URL: {}", url);
+        logger.debug("Domain: '{}'", domain);
+        logger.debug("Sub-domain: '{}'", subDomain);
+        logger.debug("Path: '{}'", path);
+        logger.debug("Parent page: {}", parentUrl);
+        logger.debug("Anchor text: {}", anchor);
+
+        if (page.getParseData() instanceof HtmlParseData) {
+            HtmlParseData htmlParseData = (HtmlParseData) page.getParseData();
+            String text = htmlParseData.getText();
+            String html = htmlParseData.getHtml();
+            Set<WebURL> links = htmlParseData.getOutgoingUrls();
+
+            logger.debug("Text length: {}", text.length());
+            logger.debug("Html length: {}", html.length());
+            logger.debug("Number of outgoing links: {}", links.size());
+        }
+
+        Header[] responseHeaders = page.getFetchResponseHeaders();
+        if (responseHeaders != null) {
+            logger.debug("Response headers:");
+            for (Header header : responseHeaders) {
+                logger.debug("\t{}: {}", header.getName(), header.getValue());
+            }
+        }
+
+        logger.debug("=============");
+    }
+}

--- a/crawler4j-examples/crawler4j-examples-dynamic/src/test/java/edu/uci/ics/crawler4j/examples/dynamic/DynamicCrawlExample.java
+++ b/crawler4j-examples/crawler4j-examples-dynamic/src/test/java/edu/uci/ics/crawler4j/examples/dynamic/DynamicCrawlExample.java
@@ -28,6 +28,7 @@ import edu.uci.ics.crawler4j.frontier.SleepycatFrontierConfiguration;
 import edu.uci.ics.crawler4j.robotstxt.RobotstxtConfig;
 import edu.uci.ics.crawler4j.url.WebURL;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,7 +113,7 @@ public class DynamicCrawlExample {
         CrawlController controller = DynamicCrawlerHelper.crawlControllerFactory(
                 config,
                 // We will wait until the body tag is loaded
-                (conf, page) -> By.cssSelector("body"),
+                (conf, page, driver) -> driver.findElement(By.cssSelector("body")),
                 new RobotstxtConfig(),
                 new SleepycatFrontierConfiguration(config));
 

--- a/crawler4j-examples/crawler4j-examples-dynamic/src/test/java/edu/uci/ics/crawler4j/examples/dynamic/DynamicCrawlExample.java
+++ b/crawler4j-examples/crawler4j-examples-dynamic/src/test/java/edu/uci/ics/crawler4j/examples/dynamic/DynamicCrawlExample.java
@@ -99,7 +99,7 @@ public class DynamicCrawlExample {
         config.setWebDriverType(DynamicCrawlConfig.WebDriverType.firefox);
 
         // Set the user agent to an actual Firefox agent
-        config.setWebDriverUserAgent("Mozilla/5.0 (X11; Linux i686; rv:109.0) Gecko/20100101 Firefox/116.0");
+        config.setUserAgentString("Mozilla/5.0 (X11; Linux i686; rv:109.0) Gecko/20100101 Firefox/116.0");
 
         // You will need to download an actual Gecko driver from https://github.com/mozilla/geckodriver/releases
         //config.setWebDriverPath("/tmp/crawler4j/driver/geckodriver-v0.33.0-linux64/geckodriver");

--- a/crawler4j-examples/crawler4j-examples-dynamic/src/test/java/edu/uci/ics/crawler4j/examples/dynamic/DynamicCrawlExample.java
+++ b/crawler4j-examples/crawler4j-examples-dynamic/src/test/java/edu/uci/ics/crawler4j/examples/dynamic/DynamicCrawlExample.java
@@ -1,0 +1,129 @@
+/*-
+ * #%L
+ * de.hs-heilbronn.mi:crawler4j-examples-base
+ * %%
+ * Copyright (C) 2010 - 2021 crawler4j-fork (pre-fork: Yasser Ganjisaffar)
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package edu.uci.ics.crawler4j.examples.dynamic;
+
+import edu.uci.ics.crawler4j.crawler.CrawlController;
+import edu.uci.ics.crawler4j.crawler.DynamicCrawlConfig;
+import edu.uci.ics.crawler4j.crawler.dynamic.DynamicCrawlerHelper;
+import edu.uci.ics.crawler4j.crawler.dynamic.DynamicWebCrawler;
+import edu.uci.ics.crawler4j.crawler.Page;
+import edu.uci.ics.crawler4j.frontier.SleepycatFrontierConfiguration;
+import edu.uci.ics.crawler4j.robotstxt.RobotstxtConfig;
+import edu.uci.ics.crawler4j.url.WebURL;
+import org.openqa.selenium.By;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DynamicCrawlExample {
+
+    private static final Logger log = LoggerFactory.getLogger(DynamicCrawlExample.class);
+
+    private static class ExampleDynamicDriver extends DynamicWebCrawler {
+
+        private final String urlPrefix;
+
+        public ExampleDynamicDriver(String urlPrefix) {
+            this.urlPrefix = urlPrefix;
+        }
+
+        @Override
+        public boolean shouldVisit(Page referringPage, WebURL url) {
+            return super.shouldVisit(referringPage, url) && url.getURL().startsWith(urlPrefix);
+        }
+
+        @Override
+        public void visit(Page page) {
+            log.info("Visiting {}", page.getWebURL().getURL());
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        DynamicCrawlConfig config = new DynamicCrawlConfig();
+
+        // Set the folder where intermediate crawl data is stored (e.g. list of urls that are extracted from previously
+        // fetched pages and need to be crawled later).
+        config.setCrawlStorageFolder("/tmp/crawler4j/");
+
+        // Be polite: Make sure that we don't send more than 2 request per second (500 milliseconds between requests).
+        // Otherwise, it may overload the target servers.
+        config.setPolitenessDelay(500);
+
+        // You can set the maximum crawl depth here. The default value is -1 for unlimited depth.
+        config.setMaxDepthOfCrawling(2);
+
+        // You can set the maximum number of pages to crawl. The default value is -1 for unlimited number of pages.
+        config.setMaxPagesToFetch(10);
+
+        // Should binary data should also be crawled? example: the contents of pdf, or the metadata of images etc
+        config.setIncludeBinaryContentInCrawling(false);
+
+        // Do you need to set a proxy? If so, you can use:
+        // config.setProxyHost("proxyserver.example.com");
+        // config.setProxyPort(8080);
+
+        // If your proxy also needs authentication:
+        // config.setProxyUsername(username); config.getProxyPassword(password);
+
+        // This config parameter can be used to set your crawl to be resumable
+        // (meaning that you can resume the crawl from a previously
+        // interrupted/crashed crawl). Note: if you enable resuming feature and
+        // want to start a fresh crawl, you need to delete the contents of
+        // rootFolder manually.
+        config.setResumableCrawling(false);
+
+        // Set this to true if you want crawling to stop whenever an unexpected error
+        // occurs. You'll probably want this set to true when you first start testing
+        // your crawler, and then set to false once you're ready to let the crawler run
+        // for a long time.
+        config.setHaltOnError(true);
+
+        // Set the headless browser configuration
+        // We will be using a Firefox driver
+        config.setWebDriverType(DynamicCrawlConfig.WebDriverType.firefox);
+
+        // Set the user agent to an actual Firefox agent
+        config.setWebDriverUserAgent("Mozilla/5.0 (X11; Linux i686; rv:109.0) Gecko/20100101 Firefox/116.0");
+
+        // You will need to download an actual Gecko driver from https://github.com/mozilla/geckodriver/releases
+        //config.setWebDriverPath("/tmp/crawler4j/driver/geckodriver-v0.33.0-linux64/geckodriver");
+        config.setWebDriverPath("/tmp/crawler4j/geckodriver-v0.33.0-linux64/geckodriver");
+
+        // We will wait at most 5 seconds for dynamic content loading
+        config.setMaxWaitForDynamicContentInSeconds(5);
+
+        // Instantiate the controller for this crawl.
+        CrawlController controller = DynamicCrawlerHelper.crawlControllerFactory(
+                config,
+                // We will wait until the body tag is loaded
+                (conf, page) -> By.cssSelector("body"),
+                new RobotstxtConfig(),
+                new SleepycatFrontierConfiguration(config));
+
+        // For each crawl, you need to add some seed urls. These are the first
+        // URLs that are fetched and then the crawler starts following links
+        // which are found in these pages
+        controller.addSeed("https://github.com/mozilla/geckodriver/releases");
+
+        // Start the crawl. This is a blocking operation, meaning that your code
+        // will reach the line after this only when crawling is finished.
+        controller.start(() -> new ExampleDynamicDriver("https://github.com/mozilla/geckodriver/"), 2);
+    }
+
+}

--- a/crawler4j-examples/crawler4j-examples-dynamic/src/test/resources/log4j2.xml
+++ b/crawler4j-examples/crawler4j-examples-dynamic/src/test/resources/log4j2.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %-5p [%t] %C{2} (%F:%L) - %m%n"/>
+        </Console>
+
+        <RollingFile name="ERRORFILE" fileName="logs/crawler4j-examples-ERROR.log"
+                     filePattern="logs/crawler4j-examples-ERROR.%d{yyyy-MM-dd}.log">
+            <ThresholdFilter level="ERROR" onMatch="ACCEPT"/>
+            <PatternLayout pattern="%d{ISO8601} %-5p [%t] %c{1}(%L): %m%n"/>
+            <TimeBasedTriggeringPolicy/>
+        </RollingFile>
+
+        <RollingFile name="WARNFILE" fileName="logs/crawler4j-examples-WARN.log"
+                     filePattern="logs/crawler4j-examples-WARN.%d{yyyy-MM-dd}.log">
+            <Filters>
+                <ThresholdFilter level="ERROR" onMatch="DENY" onMismatch="NEUTRAL"/>
+                <ThresholdFilter level="WARN" onMatch="ACCEPT"/>
+            </Filters>
+            <PatternLayout pattern="%d{ISO8601} %-5p [%t] %c{1}(%L): %m%n"/>
+            <TimeBasedTriggeringPolicy/>
+        </RollingFile>
+
+        <RollingFile name="INFOFILE" fileName="logs/crawler4j-examples-INFO.log"
+                     filePattern="logs/crawler4j-examples-INFO.%d{yyyy-MM-dd}.log">
+            <Filters>
+                <ThresholdFilter level="WARN" onMatch="DENY" onMismatch="NEUTRAL"/>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT"/>
+            </Filters>
+            <PatternLayout pattern="%d{ISO8601} %-5p [%t] %c{1}(%L): %m%n"/>
+            <TimeBasedTriggeringPolicy/>
+        </RollingFile>
+
+        <RollingFile name="DEBUGFILE" fileName="logs/crawler4j-examples-DEBUG.log"
+                     filePattern="logs/crawler4j-examples-DEBUG.%d{yyyy-MM-dd}.log">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="DENY" onMismatch="NEUTRAL"/>
+                <ThresholdFilter level="DEBUG" onMatch="ACCEPT"/>
+            </Filters>
+            <PatternLayout pattern="%d{ISO8601} %-5p [%t] %c{1}(%L): %m%n"/>
+            <TimeBasedTriggeringPolicy/>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="edu.uci.ics.crawler4j" level="INFO">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+<!--        <Logger name="edu.uci.ics.crawler4j.fetcher.SniPoolingHttpClientConnectionManager" level="WARN">-->
+<!--            <AppenderRef ref="STDOUT"/>-->
+<!--            <AppenderRef ref="ERRORFILE"/>-->
+<!--            <AppenderRef ref="WARNFILE"/>-->
+<!--            <AppenderRef ref="INFOFILE"/>-->
+<!--            <AppenderRef ref="DEBUGFILE"/>-->
+<!--        </Logger>-->
+<!--        <Logger name="edu.uci.ics.crawler4j.fetcher.SniSSLConnectionSocketFactory" level="WARN">-->
+<!--            <AppenderRef ref="STDOUT"/>-->
+<!--            <AppenderRef ref="ERRORFILE"/>-->
+<!--            <AppenderRef ref="WARNFILE"/>-->
+<!--            <AppenderRef ref="INFOFILE"/>-->
+<!--            <AppenderRef ref="DEBUGFILE"/>-->
+<!--        </Logger>-->
+        <Root level="WARN">
+            <AppenderRef ref="ERRORFILE"/>
+            <AppenderRef ref="WARNFILE"/>
+            <AppenderRef ref="INFOFILE"/>
+            <AppenderRef ref="DEBUGFILE"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/crawler4j-examples/pom.xml
+++ b/crawler4j-examples/pom.xml
@@ -14,6 +14,7 @@
     <modules>
         <module>crawler4j-examples-base</module>
         <module>crawler4j-examples-postgres</module>
+        <module>crawler4j-examples-dynamic</module>
     </modules>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,10 @@
         <maven.forbiddenapis.version>3.5.1</maven.forbiddenapis.version>
         <maven.enforcer.version>3.3.0</maven.enforcer.version>
         <maven.surefire.version>3.1.2</maven.surefire.version>
+
+        <!-- Selenium Java version -->
+        <selenium.version>4.11.0</selenium.version>
+
     </properties>
 
     <profiles>


### PR DESCRIPTION
This pull request originates from a project I did for a customer where we had to crawl one of their public websites (made with  ReactJS) for building a search engine on it. 

Starting from an initial approach in Python, it wasn't easy to maintain or to operate. So I went on taking advantage of Crawler4J since I actually hate it that everytime some dynamic website has to be crawled it's done in Python. I'd rather have a much better and easy to operate Java implementation!

It took some effort to wire together Crawler4j (which I used extensively in past projects) and a headless browser.

[The README](https://github.com/rzo1/crawler4j#reconstructing-extra-urls-to-crawl) mentions the possibility to extend the parser for such a usage scenario, so I thought it would actually be nice to make this much simpler for anyone wishing to address dynamic content crawling with Crawler4j.

The implementation makes use of Selenium's _WebDriver_ API to interface with a headless browser. It deals with the fact that _WebDriver_ is not thread-safe, so basically we instantiate one headless browser per crawler thread.

Also it offers a programmatic approach for waiting for dynamic content loading.

I'll be glad to at least have your feedback on this PR.

Things that could be done to enhance it:

- update the README (I'll definitely do it if you consider merging this)
- maybe package this feature as some sort of extension instead of having it in the core module? 

Best regards from France,

Nicolas
