### PR TITLE
Restore broken unit test

### DIFF
--- a/crawler4j-core/src/test/java/edu/uci/ics/crawler4j/tests/parser/CssParseDataTest.java
+++ b/crawler4j-core/src/test/java/edu/uci/ics/crawler4j/tests/parser/CssParseDataTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.util.Set;
 
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.helger.css.parser.ParseException;
@@ -35,7 +34,6 @@ import edu.uci.ics.crawler4j.test.Crawler4jTestUtils;
 import edu.uci.ics.crawler4j.test.TestUtils;
 import edu.uci.ics.crawler4j.url.WebURL;
 
-@Disabled(value = "Flaky test. Currently broken with latest Jacoco version!")
 public class CssParseDataTest {
 	
 	@Test

--- a/crawler4j-core/src/test/resources/css/non-parsable.css
+++ b/crawler4j-core/src/test/resources/css/non-parsable.css
@@ -1,1 +1,1 @@
-:where(.some-tile:not(.preserve-color))>*{color:#161616}
+:invalid(.some-tile:not(.preserve-color))>*{color:#161616}


### PR DESCRIPTION
`com.helger:ph-css` supports `:where` pseudo function starting from version `7.0.3`, but originally unit test expected it's not supported, thus unit test data requires updates.

https://github.com/phax/ph-css/releases/tag/ph-css-parent-pom-7.0.3:
> Added support for the `:is`, `:has` and `:where` pseudo functions