### PR TITLE
Remove conflicting dependency: `org.apache.logging.log4j:log4j-jcl`

### DIFF
--- a/crawler4j-core/pom.xml
+++ b/crawler4j-core/pom.xml
@@ -105,12 +105,6 @@
             <version>${log4j.version}</version>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jcl</artifactId>
-            <version>${log4j.version}</version>
-            <scope>runtime</scope>
-        </dependency>
 
         <!-- Compile time Dependencies -->
         <dependency>


### PR DESCRIPTION
As `org.slf4j:jcl-over-slf4j` is already in use, `org.apache.logging.log4j:log4j-jcl` should be avoided as it does exactly the same: https://logging.apache.org/log4j/2.x/faq.html#which_jars