### PR TITLE
Declare `commons-lang3` dependency explicitly

### DIFF
--- a/crawler4j-commons/pom.xml
+++ b/crawler4j-commons/pom.xml
@@ -30,6 +30,11 @@
             <version>${commons-io.version}</version>
         </dependency>
         <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+          <version>${commons-lang.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
             <version>${apache.http.client.version}</version>
@@ -75,7 +80,7 @@
             <artifactId>jul-to-slf4j</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
-        
+
 					<!-- Test dependencies -->
 					<dependency>
 						<groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
         <url-detector.version>0.1.23</url-detector.version>
         <crawler-commons.version>1.6</crawler-commons.version>
         <commons-io.version>2.22.0</commons-io.version>
+        <commons-lang.version>3.20.0</commons-lang.version>
 
         <cache2k.version>2.6.1.Final</cache2k.version>
 


### PR DESCRIPTION
To avoid build failures like this [one](https://github.com/HHN/crawler4j/actions/runs/27541299632/job/81403502525):
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.15.0:testCompile (default-testCompile) on project crawler4j-commons: Compilation failure: Compilation failure: 
Error:  /home/runner/work/crawler4j/crawler4j/crawler4j-commons/src/test/java/edu/uci/ics/crawler4j/test/SimpleWebURL.java:[22,40] package org.apache.commons.lang3.builder does not exist
Error:  /home/runner/work/crawler4j/crawler4j/crawler4j-commons/src/test/java/edu/uci/ics/crawler4j/test/SimpleWebURL.java:[23,40] package org.apache.commons.lang3.builder does not exist
Error:  /home/runner/work/crawler4j/crawler4j/crawler4j-commons/src/test/java/edu/uci/ics/crawler4j/test/SimpleWebURL.java:[33,65] cannot find symbol
Error:    symbol:   variable ToStringStyle
Error:    location: class edu.uci.ics.crawler4j.test.SimpleWebURL
Error:  /home/runner/work/crawler4j/crawler4j/crawler4j-commons/src/test/java/edu/uci/ics/crawler4j/test/SimpleWebURL.java:[33,24] cannot find symbol
Error:    symbol:   variable ToStringBuilder
Error:    location: class edu.uci.ics.crawler4j.test.SimpleWebURL
```